### PR TITLE
update electron to 13.5.1 to fix Let's Encrypt root certificate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "helium-flick",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -135,9 +135,9 @@
       }
     },
     "@electron/get": {
-      "version": "1.12.4",
-      "resolved": "https://registry.npmjs.org/@electron/get/-/get-1.12.4.tgz",
-      "integrity": "sha512-6nr9DbJPUR9Xujw6zD3y+rS95TyItEVM0NVjt1EehY2vUWfIgPiIPVHxCvaTS0xr2B+DRxovYVKbuOWqC35kjg==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-1.13.0.tgz",
+      "integrity": "sha512-+SjZhRuRo+STTO1Fdhzqnv9D2ZhjxXP6egsJ9kiO8dtP68cDx7dFCwWi64dlMQV7sWcfW1OYCW4wviEBzmRsfQ==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
@@ -1124,9 +1124,9 @@
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
     },
     "boolean": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.1.2.tgz",
-      "integrity": "sha512-YN6UmV0FfLlBVvRvNPx3pz5W/mUoYB24J4WSXOKP/OOJpi+Oq6WYqPaNTHzjI0QzwWtnvEd5CGYyQPgp1jFxnw==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.1.4.tgz",
+      "integrity": "sha512-3hx0kwU3uzG6ReQ3pnaFQPSktpBw6RHN3/ivDKEuU8g1XSfafowyvDnadjv1xp8IZqhtSukxlwv9bF6FhX8m0w==",
       "dev": true,
       "optional": true
     },
@@ -1735,9 +1735,9 @@
       }
     },
     "core-js": {
-      "version": "3.16.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.1.tgz",
-      "integrity": "sha512-AAkP8i35EbefU+JddyWi12AWE9f2N/qr/pwnDtWz4nyUIBGMJPX99ANFFRSw6FefM374lDujdtLDyhN2A/btHw==",
+      "version": "3.18.2",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.18.2.tgz",
+      "integrity": "sha512-zNhPOUoSgoizoSQFdX1MeZO16ORRb9FFQLts8gSYbZU5FcgXhp24iMWMxnOQo5uIaIG7/6FA/IqJPwev1o9ZXQ==",
       "dev": true,
       "optional": true
     },
@@ -2576,9 +2576,9 @@
       }
     },
     "electron": {
-      "version": "13.1.8",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-13.1.8.tgz",
-      "integrity": "sha512-ei2ZyyG81zUOlvm5Zxri668TdH5GNLY0wF+XrC2FRCqa8AABAPjJIWTRkhFEr/H6PDVPNZjMPvSs3XhHyVVk2g==",
+      "version": "13.5.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-13.5.1.tgz",
+      "integrity": "sha512-ZyxhIhmdaeE3xiIGObf0zqEyCyuIDqZQBv9NKX8w5FNzGm87j4qR0H1+GQg6vz+cA1Nnv1x175Zvimzc0/UwEQ==",
       "dev": true,
       "requires": {
         "@electron/get": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "autoprefixer": "^10.2.6",
     "concurrently": "^6.2.1",
     "cross-env": "^7.0.3",
-    "electron": "^13.1.8",
+    "electron": "^13.5.1",
     "electron-builder": "^22.11.7",
     "postcss": "^8.3.5",
     "postcss-nested": "^5.0.6",


### PR DESCRIPTION
This fixes api calls to longap due to expired let's encrypt root certificate